### PR TITLE
Chef 15 compatibility fixes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,8 +1,0 @@
----
-verifier:
-  name: inspec
-
-suites:
-  - name: default
-    run_list:
-      - recipe[proxytrack-test::resource_test]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,15 +1,6 @@
 AllCops:
-  Include:
-    - '**/Berksfile'
-    - '**/Cheffile'
-  Exclude:
-    - 'metadata.rb'
-
-Style/NumericLiteralPrefix:
-  EnforcedOctalStyle: zero_only
-
-Metrics/LineLength:
-  Max: 120
-
-Metrics/BlockLength:
-  Enabled: false
+  TargetChefVersion: 15.latest
+ChefModernize/FoodcriticComments:
+  Enabled: true
+ChefStyle/CopyrightCommentFormat:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,6 @@ file snakeoil_file_path => [
   'test/integration/data_bags/certificates',
   'test/integration/encrypted_data_bag_secret',
 ] do
-
   encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
     encrypted_data_bag_secret_path
   )

--- a/Rakefile
+++ b/Rakefile
@@ -110,14 +110,11 @@ task snakeoil: snakeoil_file_path
 desc 'Create an Encrypted Databag Secret'
 task secret_file: encrypted_data_bag_secret_path
 
+require 'cookstyle'
+require 'rubocop/rake_task'
 desc 'Run RuboCop (cookstyle) tests'
-task :style do
-  run_command('cookstyle')
-end
-
-desc 'Run FoodCritic (lint) tests'
-task :lint do
-  run_command('foodcritic --epic-fail any .')
+RuboCop::RakeTask.new(:style) do |task|
+  task.options << '--display-cop-names'
 end
 
 desc 'Run RSpec (unit) tests'
@@ -127,6 +124,6 @@ task :unit do
 end
 
 desc 'Run all tests'
-task test: [:style, :lint, :unit]
+task test: [:style, :unit]
 
 task default: :test

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,0 +1,13 @@
+---
+verifier:
+  name: inspec
+provisioner:
+  name: chef_solo
+  # enforce_idempotency: true # 'delete.com' test site gets created & deleted each converge
+  # multiple_converge: 2
+  deprecations_as_errors: true
+
+suites:
+  - name: default
+    run_list:
+      - recipe[proxytrack-test::resource_test]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,8 +3,8 @@ verifier:
   name: inspec
 provisioner:
   name: chef_solo
-  # enforce_idempotency: true # 'delete.com' test site gets created & deleted each converge
-  # multiple_converge: 2
+  enforce_idempotency: true
+  multiple_converge: 2
   deprecations_as_errors: true
 
 suites:

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,6 @@ chef_version     '>= 13'
 issues_url       'https://github.com/osuosl-cookbooks/proxytrack/issues'
 source_url       'https://github.com/osuosl-cookbooks/proxytrack'
 description      'Installs/Configures proxytrack'
-long_description 'Installs/Configures proxytrack'
 version          '1.0.2'
 
 supports         'centos', '~> 7.0'

--- a/spec/proxytrack-test/resource_test_spec.rb
+++ b/spec/proxytrack-test/resource_test_spec.rb
@@ -47,14 +47,7 @@ describe 'proxytrack-test::resource_test' do
       it { expect(chef_run).to start_service('proxytrack-test.com') }
 
       it do
-        expect(chef_run).to create_proxytrack('delete.com').with(
-          proxy_address: 'localhost',
-          proxy_port: 8081,
-          icp_address: 'localhost',
-          icp_port: 3131,
-          httrack_file_paths: %w(/data/archives/delete.com/hts-cache/new.zip),
-          action: [:create, :delete]
-        )
+        expect(chef_run).to delete_proxytrack('delete.com')
       end
       it { expect(chef_run).to delete_systemd_unit('proxytrack-delete.com.service') }
       it { expect(chef_run).to stop_service('proxytrack-delete.com') }

--- a/test/cookbooks/proxytrack-test/metadata.rb
+++ b/test/cookbooks/proxytrack-test/metadata.rb
@@ -6,7 +6,6 @@ chef_version     '>= 13'
 issues_url       'https://github.com/osuosl-cookbooks/proxytrack-test/issues'
 source_url       'https://github.com/osuosl-cookbooks/proxytrack-test'
 description      'Installs/Configures proxytrack-test'
-long_description 'Installs/Configures proxytrack-test'
 version          '0.1.0'
 
 supports         'centos', '~> 7.0'

--- a/test/cookbooks/proxytrack-test/recipes/resource_test.rb
+++ b/test/cookbooks/proxytrack-test/recipes/resource_test.rb
@@ -34,10 +34,5 @@ proxytrack 'test.com' do
 end
 
 proxytrack 'delete.com' do
-  proxy_address 'localhost'
-  proxy_port 8081
-  icp_address 'localhost'
-  icp_port 3131
-  httrack_file_paths %w(/data/archives/delete.com/hts-cache/new.zip)
-  action [:create, :delete]
+  action :delete
 end


### PR DESCRIPTION
Idempotency has been disabled for the test suite as the `delete.com` test site gets created and deleted on each converge